### PR TITLE
Add a flag to allow skipping uncovertable data

### DIFF
--- a/src/main/java/io/streamnative/connectors/kafka/KafkaSourceConfig.java
+++ b/src/main/java/io/streamnative/connectors/kafka/KafkaSourceConfig.java
@@ -119,6 +119,13 @@ public class KafkaSourceConfig {
                 + " is configured to `CONFIG` provider"
         )
         public String key_schema;
+
+        @FieldDoc(
+            defaultValue = "true",
+            help = "If the records read from Kafka topic are not able to be converted to the"
+                + " target schema, skip the records."
+        )
+        public boolean skip_corrupted_records = true;
         //CHECKSTYLE.ON: MemberName
     }
 


### PR DESCRIPTION
*Motivation*

When converting JSON data to AVRO data, the json data might not match the AVRO schema.
The Kafka json converter throws a NullPointerException. This pull request introduces
a flag to allow skipping these unconvertable data.