### PR TITLE
Bump log4j-core from 2.16.0 to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
     <!-- test dependencies -->
     <junit.version>4.12</junit.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <mockito.version>2.22.0</mockito.version>
     <powermock.version>2.0.0-beta.5</powermock.version>
     <streamnative-tests.version>0.0.14</streamnative-tests.version>


### PR DESCRIPTION
Bump log4j-core from 2.16.0 to 2.17.0